### PR TITLE
Adding ability to publish to maven central

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,17 @@ jobs:
           path: build/reports/jacoco/test/html
       - store_artifacts:
           path: build/libs
+  publish:
+    docker:
+      - image: cimg/openjdk:17.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Publish
+          # Version in either the tag version OR BUILD-[number]-[branch_name]-[commit]-SNAPSHOT
+          command: ./gradlew publish -PreleaseVersion=${CIRCLE_TAG:-BUILD-$CIRCLE_BUILD_NUM-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}-SNAPSHOT}
 
 workflows:
   version: 2
@@ -58,3 +69,7 @@ workflows:
       - test:
           requires:
             - build
+      - publish:
+          requires:
+            - build
+            - test

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,14 @@
 plugins {
-    id 'java'
+    id 'java-library'
+    id "maven-publish"
     id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.0'
+    id "net.linguica.maven-settings" version "0.5"
 }
 
 apply plugin: 'jacoco'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 group = 'io.github.kevvvvyp'
 version = '0.0.1-SNAPSHOT'
@@ -12,7 +16,6 @@ version = '0.0.1-SNAPSHOT'
 java {
     sourceCompatibility = '17'
 }
-
 
 bootJar {
     enabled = false
@@ -30,6 +33,65 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifact jar
+            if (project.hasProperty("releaseVersion")) {
+                version = project.releaseVersion
+            } else {
+                version = 'undefined'
+            }
+
+            pom {
+                name = 'spring-boot-simple-transactional-outbox-starter'
+                description = 'A convenient Spring Boot Starter for publishing messages via the Transactional Outbox pattern.'
+                url = 'https://github.com/kevvvvyp/spring-boot-simple-transactional-outbox-starter'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://github.com/kevvvvyp/spring-boot-simple-transactional-outbox-starter/blob/main/LICENSE'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'kevvvvyp'
+                        name = 'Kevin Paton'
+                    }
+                }
+                scm {
+                    url = 'https://github.com/kevvvvyp/spring-boot-simple-transactional-outbox-starter.git'
+                }
+            }
+
+            repositories {
+                maven {
+                    if (version.endsWith('-SNAPSHOT')) {
+                        project.logger.lifecycle("Publishing snaphot " + version + " to https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                        url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+                    } else {
+                        project.logger.lifecycle("Publishing release " + version + " to https://s01.oss.sonatype.org/content/repositories/releases/")
+                        url "https://s01.oss.sonatype.org/content/repositories/releases/"
+                    }
+
+                    name = "OSSRH"
+                    credentials {
+                        username = findProperty("ossrhUsername")
+                        password = findProperty("ossrhPassword")
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications.named("mavenJava").get()
 }
 
 dependencies {


### PR DESCRIPTION
## Description
Adding ability to publish to maven central

## Motivation and Context
So others can include this dependency in their projects without having to build the software themselves.

### What did I do?
1. Created a new project ticket at https://issues.sonatype.org/secure/CreateIssue.jspa?pid=10134&#x26;issuetype=21 
2. Generated key `gpg --gen-key`
3. Exported public key e.g. `gpg --armor --output public-key.gpg --export your@email.com
cat public-key.gpg | pbcopy`
4. Manually uploaded to `https://keyserver.ubuntu.com/`
5. Configured CircleCI & our build.gradle to publish

References
- https://maciejwalkowiak.com/blog/guide-java-publish-to-maven-central/#3-create-gpg-keys
- https://stackoverflow.com/questions/72036863/network-unreachable-when-uploading-gpg-public-key

## How Has This Been Tested?
Snapshots pushed after each build: https://s01.oss.sonatype.org/content/repositories/snapshots/io/github/kevvvvyp/spring-boot-simple-transactional-outbox-starter/ 