### PR TITLE
Permit Build & CI on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,17 +68,17 @@ workflows:
       - build:
           filters:
             tags:
-              only: *
+              only: /.*/
       - test:
           filters:
             tags:
-              only: *
+              only: /.*/
           requires:
             - build
       - publish:
           filters:
             tags:
-              only: *
+              only: /.*/
           requires:
             - build
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,20 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: *
       - test:
+          filters:
+            tags:
+              only: *
           requires:
             - build
       - publish:
+          filters:
+            tags:
+              only: *
           requires:
             - build
             - test


### PR DESCRIPTION
## Description
Permit Build & CI on tags

## Motivation and Context
Circle Ci does not permit tag workflows by default (idk why...)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

N/A