### PR TITLE
Updating release url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,8 @@ publishing {
                         project.logger.lifecycle("Publishing snaphot " + version + " to https://s01.oss.sonatype.org/content/repositories/snapshots/")
                         url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
                     } else {
-                        project.logger.lifecycle("Publishing release " + version + " to https://s01.oss.sonatype.org/content/repositories/releases/")
-                        url "https://s01.oss.sonatype.org/content/repositories/releases/"
+                        project.logger.lifecycle("Publishing release " + version + " to https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                        url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
                     }
 
                     name = "OSSRH"


### PR DESCRIPTION
## Description
Updating release url

## Motivation and Context
Not able to utilise [1.0.0-RC1 ](https://github.com/kevvvvyp/spring-boot-simple-transactional-outbox-starter/releases/tag/1.0.0-RC1) in other projects not sure why yet.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

N/A