### PR TITLE
Fixing MVN Central Release URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ publishing {
                     if (version.endsWith('-SNAPSHOT')) {
                         url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
                     } else {
-                        url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+                        url "https://s01.oss.sonatype.org/content/repositories/releases/"
                     }
 
                     name = "OSSRH"


### PR DESCRIPTION
## Description
Fixing MVN Central Release URL

## Motivation and Context
Release URL was changed as part of 1.0.0-RC2 but as we can see only RC1 is present thus it was correct the first time: https://mvnrepository.com/artifact/io.github.kevvvvyp/spring-boot-simple-transactional-outbox-starter 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

N/A