### PR TITLE
Downgrade to Spring Boot 2.7.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ public class MyApplication {
 	}
 }
 ```
+## Compatability
+### Spring
+Version: `2.7.15`
 
-## Database compatability 
+### Database 
 This project utilises Spring Data JPA (& Hibernate) so theoretically this library has the potential to support multiple different databases however only the following have been tested. 
 
 | Database | Supported Versions |

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
     id 'java-library'
     id "maven-publish"
-    id 'org.springframework.boot' version '3.1.0' apply false
+    id 'org.springframework.boot' version '2.7.15' apply false
     id "net.linguica.maven-settings" version "0.5"
 }
 
@@ -117,16 +117,16 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation "org.awaitility:awaitility"
-    testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation "org.assertj:assertj-core"
 
-    testImplementation "org.testcontainers:mysql"
     testRuntimeOnly 'com.mysql:mysql-connector-j'
-
-    testImplementation "org.testcontainers:postgresql"
     testRuntimeOnly 'org.postgresql:postgresql'
+
+    testImplementation 'org.testcontainers:testcontainers:1.19.0'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.0'
+    testImplementation "org.testcontainers:mysql:1.19.0"
+    testImplementation "org.testcontainers:postgresql:1.19.0"
 
     testImplementation('com.github.javafaker:javafaker:1.0.2') {
         exclude group: 'org.yaml', module: 'snakeyaml'

--- a/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/domain/model/OutboxEntity.java
+++ b/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/domain/model/OutboxEntity.java
@@ -3,15 +3,19 @@ package io.github.kevvvvyp.simpletransactionaloutboxstarter.domain.model;
 import java.time.Instant;
 import java.util.UUID;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,8 +40,13 @@ import lombok.ToString;
 public class OutboxEntity {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.UUID)
-	@Column(name = "id", nullable = false, unique = true)
+	@GeneratedValue(generator = "UUID")
+	@GenericGenerator(
+			name = "UUID",
+			strategy = "org.hibernate.id.UUIDGenerator"
+	)
+	@Type(type="uuid-char")
+	@Column(name = "id", columnDefinition = "VARCHAR(36)", nullable = false, unique = true)
 	private UUID id;
 
 	@Size(max = 120)
@@ -61,7 +70,13 @@ public class OutboxEntity {
 	@Column(name = "body", nullable = false)
 	private String body;
 
-	@Column(name = "locked_by")
+	@GeneratedValue(generator = "UUID")
+	@GenericGenerator(
+			name = "UUID",
+			strategy = "org.hibernate.id.UUIDGenerator"
+	)
+	@Type(type="uuid-char")
+	@Column(name = "locked_by", columnDefinition = "VARCHAR(36)")
 	private UUID lockedBy;
 
 	@Size(max = 120)

--- a/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/domain/repository/rw/OutboxRwRepository.java
+++ b/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/domain/repository/rw/OutboxRwRepository.java
@@ -1,10 +1,13 @@
 package io.github.kevvvvyp.simpletransactionaloutboxstarter.domain.repository.rw;
 
-import static org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_TIMEOUT;
+import static org.hibernate.cfg.AvailableSettings.JPA_LOCK_TIMEOUT;
 
 import java.time.Instant;
 import java.util.Collection;
 import java.util.UUID;
+
+import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,9 +21,6 @@ import org.springframework.stereotype.Repository;
 
 import io.github.kevvvvyp.simpletransactionaloutboxstarter.domain.model.OutboxEntity;
 
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.QueryHint;
-
 @Repository
 public interface OutboxRwRepository extends JpaRepository<OutboxEntity, UUID> {
 
@@ -30,7 +30,7 @@ public interface OutboxRwRepository extends JpaRepository<OutboxEntity, UUID> {
 	 * Find available messages that are ready to be sent
 	 */
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@QueryHints({ @QueryHint(name = JAKARTA_LOCK_TIMEOUT, value = SKIP_LOCKED) })
+	@QueryHints({ @QueryHint(name = JPA_LOCK_TIMEOUT, value = SKIP_LOCKED) })
 	@Query(value = """
 			SELECT o FROM OutboxEntity o
 			WHERE (

--- a/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/service/delivery/OutboxDao.java
+++ b/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/service/delivery/OutboxDao.java
@@ -25,7 +25,7 @@ import io.github.kevvvvyp.simpletransactionaloutboxstarter.service.MessageOutbox
 import io.github.kevvvvyp.simpletransactionaloutboxstarter.service.OutboxDeliveryStrategy;
 import io.github.kevvvvyp.simpletransactionaloutboxstarter.transfer.Message;
 
-import jakarta.validation.constraints.NotNull;
+import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/transfer/Message.java
+++ b/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/transfer/Message.java
@@ -2,7 +2,7 @@ package io.github.kevvvvyp.simpletransactionaloutboxstarter.transfer;
 
 import java.time.Instant;
 
-import jakarta.validation.constraints.NotBlank;
+import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder(toBuilder = true)


### PR DESCRIPTION
## Description
Downgrade to 2.7.15

## Motivation and Context
Starting off with a 2.7xx version then will upgrade to 3xx in a later releases to provide some options for library consumers.

## How Has This Been Tested?

N/A