### PR TITLE
Fix: Quick workaround to allow consumers using different packages to autowire in the dao

### DIFF
--- a/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/domain/model/EntityMarker.java
+++ b/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/domain/model/EntityMarker.java
@@ -1,3 +1,5 @@
 package io.github.kevvvvyp.simpletransactionaloutboxstarter.domain.model;
 
-public interface EntityMarker {}
+public interface EntityMarker {
+	String ENTITY_MARKER = "io.github.kevvvvyp.simpletransactionaloutboxstarter.domain.model";
+}

--- a/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/service/delivery/OutboxDao.java
+++ b/src/main/java/io/github/kevvvvyp/simpletransactionaloutboxstarter/service/delivery/OutboxDao.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Service
-class OutboxDao {
+public class OutboxDao {
 	private final OutboxRoRepository readOnlyRepository;
 	private final OutboxRwRepository readWriteRepository;
 	private final OutboxConfiguration config;


### PR DESCRIPTION
## Description
Fix: Quick workaround to allow consumers using different packages to autowire in the dao

## Motivation and Context
Consumers fail to autowire the OutboxService as the Polling service can't utilise the dao.


## How Has This Been Tested?
Automation passing.